### PR TITLE
Correct sv_browse example arguments in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ if input vcf,format:
 |------|------|------|------|------|------|------|------|------|------|
 |5|17101355|sv549|N|<DEL>|.|pass|SVLEN=107;SVTYPE=DEL;END=17101462|GT|0/1|
 ```
-SVhaweye.py -i tumor.bam,normal.bam -b test.vcf --format vcf -d 1000 -o test -g hg19
-SVhaweye.py -i sample.bam -b test.vcf --format vcf -o test -g hg38 -q 20 -fo pdf
+haweye.py -i tumor.bam,normal.bam -b test.vcf -f vcf -d 1000 -o test -g hg19
+haweye.py -i sample.bam -b test.vcf -f vcf -o test -g hg38 -q 20 -F pdf
 ```
 
 # Output


### PR DESCRIPTION
Hello -- thanks for the fantastic tool!  

I just wanted to contribute some minor updates to the example code -- it looks like the calls to `sv_browse` with **vcf** as the input format were using out-of-date notation.  Calling them as-is was causing crashes.

Here's the original pair of examples:
```
SVhaweye.py -i tumor.bam,normal.bam -b test.vcf --format vcf -d 1000 -o test -g hg19
SVhaweye.py -i sample.bam -b test.vcf --format vcf -o test -g hg38 -q 20 -fo pdf
```

I changed `SVhawkeye.py` to `hawkeye.py` to reflect the new name of the main script, `--format vcf` to `-f vcf` (`--format` was no longer recognized as an argument and caused crashes), and `-fo pdf` to `-F pdf` (`-fo pdf` caused the program to incorrectly attempt to parse the VCF as a bed, for some reason).

```
haweye.py -i tumor.bam,normal.bam -b test.vcf -f vcf -d 1000 -o test -g hg19
haweye.py -i sample.bam -b test.vcf -f vcf -o test -g hg38 -q 20 -F pdf
```

Thanks again, and hope this helps!